### PR TITLE
Return multiple products on the product page.

### DIFF
--- a/final-project/application.py
+++ b/final-project/application.py
@@ -523,10 +523,15 @@ def product():
     # brand = product_info[0]["brand"]
     # price = usd(product_info[0]["price"])
 
-    # Get product references
-    (number_of_references,
-    reference_titles,
-    reference_links) = get_reference(product_name)
+    # Make a list to store product names
+    product_list = []
+
+    # Store each product name into the list
+    for product in product_info:
+        product_list.append(product["product_name"])
+
+    # Get references for each product in the list
+    article_references = get_reference(product_list)
 
     #Render the product page.
     return render_template("product.html",
@@ -538,6 +543,7 @@ def product():
                             # description=description,
                             # brand=brand,
                             # price=price,
-                            number_of_references=number_of_references,
-                            reference_titles=reference_titles,
-                            reference_links=reference_links)
+                            # number_of_references=number_of_references,
+                            # reference_titles=reference_titles,
+                            # reference_links=reference_links
+                            article_references=article_references)

--- a/final-project/application.py
+++ b/final-project/application.py
@@ -513,16 +513,15 @@ def product():
     # If no product was found, then apologize.
     if not product_info or product_info == None:
         return apology("Sorry, we don't have information for that product")
-    elif len(product_info) > 1:
-        return apology("Found more than a single product. Please try again.")
 
-    # Assign local variables
+
+    # # Assign local variables
     product_name = product_info[0]["product_name"]
-    image = product_info[0]["image"]
-    link = product_info[0]["link"]
-    description = product_info[0]["description"]
-    brand = product_info[0]["brand"]
-    price = usd(product_info[0]["price"])
+    # image = product_info[0]["image"]
+    # link = product_info[0]["link"]
+    # description = product_info[0]["description"]
+    # brand = product_info[0]["brand"]
+    # price = usd(product_info[0]["price"])
 
     # Get product references
     (number_of_references,
@@ -531,12 +530,14 @@ def product():
 
     #Render the product page.
     return render_template("product.html",
-                            product_name=product_name,
-                            image=image,
-                            link=link,
-                            description=description,
-                            brand=brand,
-                            price=price,
+                            product_info=product_info,
+                            product_request=product_request,
+                            # product_name=product_name,
+                            # image=image,
+                            # link=link,
+                            # description=description,
+                            # brand=brand,
+                            # price=price,
                             number_of_references=number_of_references,
                             reference_titles=reference_titles,
                             reference_links=reference_links)

--- a/final-project/helpers.py
+++ b/final-project/helpers.py
@@ -187,52 +187,64 @@ def find_product(product_requested):
     return product_data
 
 
-def get_reference(product_with_references):
+def get_reference(list_of_products):
     """Search for references to product research."""
 
     # If no name is given, then ask the user for one.
-    if not product_with_references:
-        return apology("Please specify product")
-    elif product_with_references == None:
-        return apology("Please specify product")
+    if not list_of_products:
+        return None
+    elif list_of_products == None:
+        return None
 
-    # Search for references to a given product
-    references_for_product = db.execute("""
-            SELECT research.link, title
-            FROM research
-            LEFT JOIN products
-            ON products.id=research.product_id
-            WHERE products.product_name=:product
-            """, product=product_with_references)
+    # Create list to store references
+    reference_list = []
 
-    # Check whether we found references
-    if not references_for_product:
-        return apology("We have no references. Please help us research")
-    elif references_for_product == None:
-        return apology("We have no references. Please help us research")
+    # Look at each product in the list of products
+    for product_name in list_of_products:
 
-    # Save the number of research articles for this products.
-    number_of_references = len(references_for_product)
+        # Search for references to a given product
+        reference_returned = db.execute("""
+                SELECT research.link, title
+                FROM research
+                LEFT JOIN products
+                ON products.id=research.product_id
+                WHERE products.product_name=:product
+                """, product=product_name)
 
-    # Save the titles and links to each reference.
-    # Create an empty list to save our titles.
-    reference_titles = []
-    # Create an empty list to save our links.
-    reference_links = []
+        # TODO: Store values into a dictionary object
 
-    # Loop through each title in our list of references
-    for reference_article in references_for_product:
 
-        # Ensure we have a title.
-        if not reference_article["title"]:
-            # If there is no title, then use the link.
-            reference_titles.append(reference_article["link"])
-        # If there is a title, then use the title.
-        else:
-            # Save the title.
-            reference_titles.append(reference_article["title"])
+        # Save the number of research articles for this products.
+        number_of_references = len(reference_returned)
 
-        # Save the link.
-        reference_links.append(reference_article["link"])
+        # Save the titles and links to each reference.
+        # Create an empty list to save our titles.
+        reference_titles = []
+        # Create an empty list to save our links.
+        reference_links = []
 
-    return (number_of_references, reference_titles, reference_links)
+
+        # Loop through each title in our list of references
+        for reference_article in reference_returned:
+
+            # Ensure we have a title.
+            if not reference_article["title"]:
+                # If there is no title, then use the link.
+                reference_titles.append(reference_article["link"])
+            # If there is a title, then use the title.
+            else:
+                # Save the title.
+                reference_titles.append(reference_article["title"])
+
+            # Save the link.
+            reference_links.append(reference_article["link"])
+
+
+        # TODO: Save dict objects into the reference list
+
+
+
+
+
+
+    # TODO: Return a list of dict objects

--- a/final-project/templates/product.html
+++ b/final-project/templates/product.html
@@ -3,42 +3,44 @@
 {% extends "layout.html" %}
 
 {% block title %}
-    {{product_name}}
+    {{product_request}} product request
 {% endblock %}
 
 {% block main %}
-    <header>
-        <h1>{{product_name}}</h1><h5>{{brand}}</h5>
-    </header>
-    <div class=container-fluid>
+    {% for product in product_info %}
+        <header>
+            <h1>{{product["product_name"]}}</h1><h5>{{product["brand"]}}</h5>
+        </header>
+        <div class=container-fluid>
 
-        <div>
-            <img src="{{image}}" alt="Picture of {{product_name}}" height=350>
+            <div>
+                <img src="{{product["image"]}}" alt="Picture of {{product["product_name"]}}" height=350>
+            </div>
+
+            <div>
+                <h4>{{product["price"]}}</h4>
+            </div>
+
+            <h1>Description</h1>
+            <p>{{product["description"]}}</p>
+
+            <!--TODO: Render characteristics of product on the page-->
+            <h2>Characteristics</h2>
+            <div>
+                <p>Plastic Free</p>
+                <p>Ethically Made</p>
+            </div>
+
+            <div id=references>
+                <h3>References</h3>
+                {% for reference in range(number_of_references) %}
+                    <a href='{{reference_links[reference]}}'>
+                        {{reference_titles[reference]}}
+                    </a>
+                {% endfor %}
+            </div>
+
         </div>
-
-        <div>
-            <h4>{{price}}</h4>
-        </div>
-
-        <h1>Description</h1>
-        <p>{{description}}</p>
-
-        <!--TODO: Render characteristics of product on the page-->
-        <h2>Characteristics</h2>
-        <div>
-            <p>Plastic Free</p>
-            <p>Ethically Made</p>
-        </div>
-
-        <div id=references>
-            <h3>References</h3>
-            {% for reference in range(number_of_references) %}
-                <a href='{{reference_links[reference]}}'>
-                    {{reference_titles[reference]}}
-                </a>
-            {% endfor %}
-        </div>
-
-    </div>
+    {% endfor %}
 
 {% endblock %}

--- a/final-project/templates/product.html
+++ b/final-project/templates/product.html
@@ -33,10 +33,13 @@
 
             <div id=references>
                 <h3>References</h3>
-                {% for reference in range(number_of_references) %}
-                    <a href='{{reference_links[reference]}}'>
-                        {{reference_titles[reference]}}
-                    </a>
+                {% for article in article_references %}
+                    number_of_articles = article[number_of_references]
+                    {% for reference in range(number_of_articles) %}
+                        <a href='{{ article[reference_links[reference]] }}'>
+                            {{ article[reference_titles[reference]] }}
+                        </a>
+                    {% endfor %}
                 {% endfor %}
             </div>
 


### PR DESCRIPTION
***UPDATED**: PR closed without merge. Branch deleted. Feature obsolete.*

This is to address @hdavidzhu comment in the following PR.

**PR**
If more than a single product is returned tell the user. #37

**Comment** 
"That's actually kinda strange. Why wouldn't you return multiple products? If you ever only need one product, you should have an ID for it."