### PR TITLE
Fetch product data via get after html page load.

### DIFF
--- a/final-project/application.py
+++ b/final-project/application.py
@@ -489,9 +489,9 @@ def update():
     return apology("TODO Update")
 
 
-@app.route("/productJSON")
+@app.route("/get-product-json")
 @login_required
-def productJSON():
+def getProductJSON():
     """View an individual product"""
 
     # Keep the user logged in.
@@ -522,20 +522,24 @@ def productJSON():
     reference_titles,
     reference_links) = get_reference(product_info[0]["product_name"])
 
-    # add references to our product information
+    # Add references to our product information.
     product_info[0]['number_of_references'] = number_of_references
     product_info[0]['reference_titles'] = reference_titles
     product_info[0]['reference_links'] = reference_links
 
-    # Return json of product information
-    productJSON = jsonify(product_info[0])
 
+    # Helpful Documentation:
+    # MDN Cross-Origin Sharing Functional Overview
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 
-    # BIG TODO: This is the incorrect process.
-        # TODO: The HTTP request for JSON needs to happen via AJAX.
+    # Return product information in the form of a JSON object.
+    return jsonify(product_info[0])
+
+@app.route("/product")
+def renderProductPage():
+
     # Display the product html page
-    return render_template("productJSON.html", productJSON=productJSON)
-
+    return render_template("productJSON.html")
 
 @app.route("/edit")
 @login_required

--- a/final-project/application.py
+++ b/final-project/application.py
@@ -490,7 +490,7 @@ def update():
 
 
 @app.route("/get-product-json")
-@login_required
+# @login_required
 def getProductJSON():
     """View an individual product"""
 
@@ -538,8 +538,18 @@ def getProductJSON():
 @app.route("/product")
 def renderProductPage():
 
+    # Request a product from the user.
+    idOfProductsRequested = request.args.get("id")
+
+    # Ensure the user asked for a product.
+    if not idOfProductsRequested:
+        return apology("Please let us know which product you are looking for")
+    elif idOfProductsRequested == None:
+        return apology("Please let us know which product you are looking for")
+
+
     # Display the product html page
-    return render_template("productJSON.html")
+    return render_template("productJSON.html", idOfProductsRequested=idOfProductsRequested)
 
 @app.route("/edit")
 @login_required

--- a/final-project/static/scripts.js
+++ b/final-project/static/scripts.js
@@ -13,6 +13,10 @@ $(function(){
   if ( !!(document.querySelector(".product-page")) ) {
     // Pull the id from the URL, then return a JSON object.
     retrieveJSON(getSearchParams());
+
+    // TODO: Display the product information on screen.
+    // Call displayProduct();
+
   }
 
   // If there are product thumbnails on the page, then make them clickable.
@@ -150,18 +154,89 @@ function renderProductPage(productIdentificationNumber) {
 // Display the product information on the page
 function displayProduct() {
 
+  // Select DOM elements by css class.
+  // document.querySelector
 
-  // TODO: Listen for when a product page loads.
+    // DOM
+    // Select header.
+      // Select product name.
+      // Select brand.
 
-    // TODO: Get the product id.
+    // Select product image.
 
-    // TODO: Get the product information based on id.
+    // Select link.
 
-    // TODO: Set the relevant elements to display product information.
+    // Select price.
 
-      // TODO: Select the desired DOM element.
+    // Select description.
 
-      // TODO: Parse the responseJSON for the data to show on screen.
+    // Select characteristics
+
+    // Select references.
+      // Select ordered list of references.
+
+
+    // Available product info.
+    // id
+    // category_id
+    // product_name
+    // link
+    // description
+    // image
+    // brand
+    // price
+
+    // Available reference info.
+    // id
+    // product_id
+    // title
+    // link
+
+
+  // Set content.
+  // Element.textContent
+
+  // Store JavaScript Object Notation JSON
+  // in a variable to access later.
+
+    // Set header.
+      // Set product name.
+        // Pull product name from JavaScript object.
+        // Set text content to equal JavaScript object content.
+      // Set brand.
+
+    // Set product image.
+
+    // Set link.
+
+    // Set price.
+
+    // Set description.
+
+    // Set characteristics
+      // Populate with empty state values
+      // until characteristics are available.
+      // TODO: Create characteristics in DB.
+      // See the productJSON.html note
+      // for details about structure.
+
+
+    // Set references.
+      // Create list item.
+
+      // Loop through all references for product.
+        // Create reference variable.
+        // Make it an anchor element.
+          // Set text content to title.
+          // Set href attribute to link.
+        // Append to the list item.
+
+      // Append list items to ordered list.
 
 
 };
+
+// TODO: Render "edit product info" UI.
+
+
+// TODO: Create generic page update function for interactive tasks.

--- a/final-project/static/scripts.js
+++ b/final-project/static/scripts.js
@@ -211,7 +211,7 @@ function displayProduct(jsonOfProductInfo) {
   prodPageBrand.textContent = productJsonInfo['brand'];
 
   // Set product image.
-  prodPageImage.setAttribute('src', productJsonInfo['image'])
+  prodPageImage.setAttribute('src', productJsonInfo['image']);
 
   // Set price.
   prodPagePrice.textContent = "$" + productJsonInfo['price'];
@@ -233,15 +233,15 @@ function displayProduct(jsonOfProductInfo) {
   var referenceListItem = document.createElement('li');
 
   // Loop through all references for product.
-  for (i = 0; i < productJsonInfo['references_titles'].length; i++) {
+  for (var i = 0; i < productJsonInfo['reference_titles'].length; i++) {
 
     // Create reference variable.
     // Make it an anchor element.
     var referenceItemContent = document.createElement('a');
-      // Set text content to title.
-      referenceItemContent.textContent = productJsonInfo['reference_titles'][i];
-      // Set href attribute to link.
-      referenceItemContent.setAttribute("href", productJsonInfo['reference_links'][i]);
+    // Set text content to title.
+    referenceItemContent.textContent = productJsonInfo['reference_titles'][i];
+    // Set href attribute to link.
+    referenceItemContent.setAttribute("href", productJsonInfo['reference_links'][i]);
     // Append to the list item.
     referenceListItem.appendChild(referenceItemContent);
 

--- a/final-project/static/scripts.js
+++ b/final-project/static/scripts.js
@@ -12,11 +12,10 @@ $(function(){
   // Get product data when user navigates to a product page.
   if ( !!(document.querySelector(".product-page")) ) {
     // Pull the id from the URL, then return a JSON object.
-    retrieveJSON(getSearchParams());
+    var jsonProductReturned = retrieveJSON(getSearchParams());
 
-    // TODO: Display the product information on screen.
-    // Call displayProduct();
-    // Pass the JSON to the display function.
+    // Display the product information on screen.
+    displayProduct(jsonProductReturned);
 
   }
 

--- a/final-project/static/scripts.js
+++ b/final-project/static/scripts.js
@@ -9,32 +9,20 @@
 // Check what kind of content to load when the document is ready.
 $(function(){
 
+  // Get product data when user navigates to a product page.
+  if ( !!(document.querySelector(".product-page")) ) {
+    // Pull the id from the URL, then return a JSON object.
+    retrieveJSON(getSearchParams());
+  }
+
   // If there are product thumbnails on the page, then make them clickable.
   if ( !!(document.querySelector(".clickable-products")) ) {
-
-
-    // BIG TODO: Only use fetch product data after the product page has been rendered.
-    // The browser's CORS security prevents cross-origin requests.
-    // Answer 1:
-    // https://stackoverflow.com/questions/42719041/how-to-resolve-typeerror-networkerror-when-attempting-to-fetch-resource
-    // Answer 2:
-    // https://stackoverflow.com/questions/37333573/fetch-with-the-wikipedia-api-results-in-typeerror-networkerror-when-attempti#37351064
-    // Documentation:
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
-    // Explanation:
-    // These answers and documentation explain the failure in my previous code.
-
-    // BIG TODO 2: The JSON is currently retrieved by asking Flask
-    // to render a URL which returns a json. This will not work, because the url
-    // would have to be different than the current page.
-    // Need to get JSON from our python application without using the Flask.url_for
-    // method. There must be some other way to do this, but it requires more research.
-    // How does one call a python function from javascript? <-- John, answer this.
 
 
     // Small TODO: Update this to add a listener on all the products on page.
     // Small TODO: use the event object to select the appropriate product.
     // Keep track of the products we have on screen.
+    // BUG: This only listens for clicks on the first product on the page, not all.
     var productWasClicked = document.querySelector(".clickable-products");
 
     // TODO: Replace with a promise chain.
@@ -66,20 +54,10 @@ $(function(){
       renderProductPage(productIdNumber);
 
 
-      // Get information for the product our user selects.
-      var productInformation = retrieveJSON(getSearchParams);
-
-
     });
 
   }
 
-  // If the user is on a product page, then load product content.
-  if ( !!( document.querySelector(".product-page") ) ) {
-
-    // TODO: load relevant product content
-
-  }
 
 });
 
@@ -101,32 +79,31 @@ function getSearchParams() {
 // Retrieve product information in the form of a JSON.
 function retrieveJSON(product_id) {
 
-  console.log(" ");
-  console.log("retreiveJSON function started");
 
   // Create parameters for Flask.url_for() method.
   var parameters = {
     id: product_id
   }
-  console.log(" ");
-  console.log("parameters:");
-  console.log(parameters);
+
 
   // Set URL to find the product json.
-  var productUrl = Flask.url_for('product', parameters);
+  var productUrl = Flask.url_for("getProductJSON", parameters);
   console.log('');
   console.log('productUrl built by Flask.url_for');
   console.log(productUrl);
 
-  // Create a variable to store the products.
-  var productsJsonData;
 
   // Fetch product information.
   fetch(productUrl).then(function(response) {
     if(response.ok) {
       response.json().then(function(json) {
-        // Store the JSON data in a properly scoped variable.
-        productsJsonData = json;
+
+        // Print the data to the console for testing.
+        console.log('');
+        console.log('Success: fetch resolved!')
+        console.log('The JSON data is below.')
+        console.log(json);
+        return json;
       })
     } else {
       // Print an error if nothing was found.
@@ -138,14 +115,6 @@ function retrieveJSON(product_id) {
     }
   });
 
-  // Print the data to the console for testing.
-  console.log('');
-  console.log(productsJsonData);
-  return productsJsonData;
-
-  // How to resolve “TypeError: NetworkError when attempting to fetch resource.""
-  // https://stackoverflow.com/questions/42719041/how-to-resolve-typeerror-networkerror-when-attempting-to-fetch-resource
-
 }
 
 // Get the product id when it is clicked.
@@ -156,9 +125,6 @@ function getIdOnClick(productClicked) {
 
   // Get the id of a product when it is clicked.
   var productIdOfClicked = productClicked.id
-  console.log(" ")
-  console.log("Heard click")
-  console.log("product id is " + productIdOfClicked)
 
 
   // Return the product's id.
@@ -169,11 +135,14 @@ function getIdOnClick(productClicked) {
 
 
 // Redirect user to the Product page
-function renderProductPage() {
+function renderProductPage(productIdentificationNumber) {
+
+  var parameters = {
+    id: productIdentificationNumber
+  }
 
   // Render the product page with the selected product name and id.
-  window.location.href = Flask.url_for("product", parameters);
-
+  window.location.replace(Flask.url_for("renderProductPage", parameters));
 
 }
 

--- a/final-project/static/scripts.js
+++ b/final-project/static/scripts.js
@@ -82,13 +82,6 @@ function getSearchParams() {
 // Retrieve product information in the form of a JSON.
 function retrieveJSON(product_id) {
 
-
-  // Create parameters for Flask.url_for() method.
-  var parameters = {
-    id: product_id
-  }
-
-
   // Set URL to find the product json.
   var productUrl = Flask.url_for("getProductJSON", parameters);
   console.log('');
@@ -116,7 +109,9 @@ function retrieveJSON(product_id) {
         + response.statusText
       );
     }
+
   });
+
 
 }
 
@@ -204,39 +199,52 @@ function displayProduct(jsonOfProductInfo) {
   // Element.textContent
 
   // Set product name.
-  // Pull product name from JavaScript object.
-  prodPageName =
-  // Set text content to equal JavaScript object content.
+  prodPageName.textContent = productJsonInfo['product_name'];
   // Set id of product name.
+  prodPageName.setAttribute('id', productJsonInfo['product_name']);
+
   // Set brand.
+  prodPageBrand.textContent = productJsonInfo['brand'];
 
   // Set product image.
-
-  // Set link.
+  prodPageImage.setAttribute('src', productJsonInfo['image'])
 
   // Set price.
+  prodPagePrice.textContent = "$" + productJsonInfo['price'];
 
   // Set description.
+  prodPageDescription.textContent = productJsonInfo['description'];
 
-  // Set characteristics
-    // Populate with empty state values
-    // until characteristics are available.
+  // Set characteristics.
+  // Populate with empty state values
+  // until characteristics are available.
+  prodPageCharacteristics.textContent = "This section is under construction.";
     // TODO: Create characteristics in DB.
     // See the productJSON.html note
     // for details about structure.
 
 
   // Set references.
-    // Create list item.
+  // Create list item.
+  var referenceListItem = document.createElement('li');
 
-    // Loop through all references for product.
-      // Create reference variable.
-      // Make it an anchor element.
-        // Set text content to title.
-        // Set href attribute to link.
-      // Append to the list item.
+  // Loop through all references for product.
+  for (i = 0; i < productJsonInfo['references_titles'].length; i++) {
+
+    // Create reference variable.
+    // Make it an anchor element.
+    var referenceItemContent = document.createElement('a');
+      // Set text content to title.
+      referenceItemContent.textContent = productJsonInfo['reference_titles'][i];
+      // Set href attribute to link.
+      referenceItemContent.setAttribute("href", productJsonInfo['reference_links'][i]);
+    // Append to the list item.
+    referenceListItem.appendChild(referenceItemContent);
 
     // Append list items to ordered list.
+    prodPageReferences.appendChild(referenceListItem);
+
+  }
 
 
 };

--- a/final-project/static/scripts.js
+++ b/final-project/static/scripts.js
@@ -82,6 +82,10 @@ function getSearchParams() {
 // Retrieve product information in the form of a JSON.
 function retrieveJSON(product_id) {
 
+  var parameters = {
+    id: product_id
+  };
+
   // Set URL to find the product json.
   var productUrl = Flask.url_for("getProductJSON", parameters);
   console.log('');

--- a/final-project/static/scripts.js
+++ b/final-project/static/scripts.js
@@ -12,10 +12,8 @@ $(function(){
   // Get product data when user navigates to a product page.
   if ( !!(document.querySelector(".product-page")) ) {
     // Pull the id from the URL, then return a JSON object.
-    var jsonProductReturned = retrieveJSON(getSearchParams());
-
-    // Display the product information on screen.
-    displayProduct(jsonProductReturned);
+    // Display data on screen when fetch resolves.
+    retrieveJSON(getSearchParams());
 
   }
 
@@ -108,7 +106,7 @@ function retrieveJSON(product_id) {
         console.log('Success: fetch resolved!')
         console.log('The JSON data is below.')
         console.log(json);
-        return json;
+        displayProduct(json);
       })
     } else {
       // Print an error if nothing was found.

--- a/final-project/static/scripts.js
+++ b/final-project/static/scripts.js
@@ -16,6 +16,7 @@ $(function(){
 
     // TODO: Display the product information on screen.
     // Call displayProduct();
+    // Pass the JSON to the display function.
 
   }
 
@@ -30,7 +31,8 @@ $(function(){
     var productWasClicked = document.querySelector(".clickable-products");
 
     // TODO: Replace with a promise chain.
-    // Promises will ensure functions call at the correct time to avoid CORS error.
+    // Promises will ensure functions call at the correct time.
+    // JSON is required before document set.
 
     // TODO: Create new promise object to get identification of product clicked
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
@@ -152,28 +154,36 @@ function renderProductPage(productIdentificationNumber) {
 
 
 // Display the product information on the page
-function displayProduct() {
+function displayProduct(jsonOfProductInfo) {
 
   // Select DOM elements by css class.
   // document.querySelector
 
-    // DOM
-    // Select header.
-      // Select product name.
-      // Select brand.
+  // Select product name.
+  var prodPageName = document.querySelector('.product-name');
+  // Select brand.
+  var prodPageBrand = document.querySelector('.brand');
 
-    // Select product image.
+  // Select product image.
+  var prodPageImage = document.querySelector('.product-image');
 
-    // Select link.
+  // Select price.
+  var prodPagePrice = document.querySelector('.price');
 
-    // Select price.
+  // Select description.
+  var prodPageDescription = document.querySelector('.description');
 
-    // Select description.
+  // Select characteristics
+  var prodPageCharacteristics = document.querySelector('.characteristics');
 
-    // Select characteristics
+  // Select references.
+  // Select ordered list of references.
+  var prodPageReferences = document.querySelector('.references-list');
 
-    // Select references.
-      // Select ordered list of references.
+
+  // Store JavaScript Object Notation JSON
+  // in a variable to access later.
+  var productJsonInfo = jsonOfProductInfo;
 
 
     // Available product info.
@@ -196,42 +206,40 @@ function displayProduct() {
   // Set content.
   // Element.textContent
 
-  // Store JavaScript Object Notation JSON
-  // in a variable to access later.
+  // Set product name.
+  // Pull product name from JavaScript object.
+  prodPageName =
+  // Set text content to equal JavaScript object content.
+  // Set id of product name.
+  // Set brand.
 
-    // Set header.
-      // Set product name.
-        // Pull product name from JavaScript object.
-        // Set text content to equal JavaScript object content.
-      // Set brand.
+  // Set product image.
 
-    // Set product image.
+  // Set link.
 
-    // Set link.
+  // Set price.
 
-    // Set price.
+  // Set description.
 
-    // Set description.
-
-    // Set characteristics
-      // Populate with empty state values
-      // until characteristics are available.
-      // TODO: Create characteristics in DB.
-      // See the productJSON.html note
-      // for details about structure.
+  // Set characteristics
+    // Populate with empty state values
+    // until characteristics are available.
+    // TODO: Create characteristics in DB.
+    // See the productJSON.html note
+    // for details about structure.
 
 
-    // Set references.
-      // Create list item.
+  // Set references.
+    // Create list item.
 
-      // Loop through all references for product.
-        // Create reference variable.
-        // Make it an anchor element.
-          // Set text content to title.
-          // Set href attribute to link.
-        // Append to the list item.
+    // Loop through all references for product.
+      // Create reference variable.
+      // Make it an anchor element.
+        // Set text content to title.
+        // Set href attribute to link.
+      // Append to the list item.
 
-      // Append list items to ordered list.
+    // Append list items to ordered list.
 
 
 };

--- a/final-project/templates/productJSON.html
+++ b/final-project/templates/productJSON.html
@@ -15,10 +15,8 @@
             <h5 class="brand"></h5>
         </header>
 
+        <img class="product-image" src="" alt="Picture of product" height=350>
 
-        <div class="product-image">
-            <img src="" alt="Picture of product" height=350>
-        </div>
 
         <h4>Price</h4>
         <div class="price">

--- a/final-project/templates/productJSON.html
+++ b/final-project/templates/productJSON.html
@@ -32,19 +32,23 @@
 
         <h2>Characteristics</h2>
         <div class=characteristics>
-            <p></p>
+            <!--TODO: Set characteristics in database-->
+            <!--Don't pre-mature optimize.-->
+            <!--Set the characteristics on the product itself.-->
+            <!--Boolean values in characteristic column.-->
         </div>
 
         <div class="references">
             <h3>References</h3>
-            <span class="title"></span>
-            <p></p>
-            <span class="link"></span>
+            <span class="external-references">
+                <ol class="references-list"></ol>
+            </span>
         </div>
 
         <div class="edit">
             <label for="edit-product">Is this info correct?</label>
             <input id="edit-product" type="button" value="edit product"/>
+            <!--TODO: Enter edit mode on click.-->
         </div>
 
 

--- a/final-project/templates/productJSON.html
+++ b/final-project/templates/productJSON.html
@@ -11,7 +11,7 @@
     <div class="product-page container-fluid">
 
         <header>
-            <h1 class="product-name"></h1>
+            <h1 class="product-name" id="{{idOfProductsRequested}}"></h1>
             <h5 class="brand"></h5>
         </header>
 


### PR DESCRIPTION
This PR fixes the HTTP request issue from earlier. The http request is sent after the product page loads. It leverages the URL this way users can share a product link and still retrieve the necessary data. 

The data is only logged in the console at this point. 

Next is to display it on the page. I will create another branch off this branch to display the product data before merge. This will ensure no non-usable code is merged into master.