### PR TITLE
Fix: Only display references for a specific product

### DIFF
--- a/final-project/application.py
+++ b/final-project/application.py
@@ -525,7 +525,7 @@ def getProductJSON():
     (number_of_references,
     reference_ids,
     reference_titles,
-    reference_links) = get_reference(product_info[0]["product_name"])
+    reference_links) = get_reference(id_products_request)
 
     # Add references to our product information.
     product_info[0]['number_of_references'] = number_of_references
@@ -724,7 +724,7 @@ def get_new_info(get_info_for_product_with_this_id):
     (number_of_references,
     reference_ids,
     reference_titles,
-    reference_links) = get_reference(product_info[0]["product_name"])
+    reference_links) = get_reference(product_id_of_the_request)
 
     # Append the references to our product information.
     product_info[0]['number_of_references'] = number_of_references

--- a/final-project/helpers.py
+++ b/final-project/helpers.py
@@ -196,13 +196,16 @@ def get_reference(product_with_references):
     elif product_with_references == None:
         return apology("Please specify product")
 
+    print('')
+    print('get_reference line 200')
+    print('')
     # Search for references to a given product
     references_for_product = db.execute("""
             SELECT research.link, title, research.id
             FROM research
             LEFT JOIN products
             ON products.id=research.product_id
-            WHERE products.product_name=:product
+            WHERE products.id=:product
             """, product=product_with_references)
 
     # Save the number of research articles for this products.


### PR DESCRIPTION
Steps to Reproduce:
1. View product
Expected: Only references related to the current product would show.
Actual: All the references in the database would show.

Fix:
Change reference request to use the product's id, not the product's name.