### PR TITLE
Fix: Remove characteristics form

### DIFF
--- a/final-project/static/scripts.js
+++ b/final-project/static/scripts.js
@@ -314,9 +314,6 @@ function renderEditProductForm() {
     // Select description.
     var prodPageDescription = document.querySelector('.description');
 
-    // Select characteristics
-    var prodPageCharacteristics = document.querySelector('.characteristics');
-
     // Select references.
     // Select ordered list of references.
     var prodPageReferences = document.querySelector('.references-list');
@@ -332,7 +329,6 @@ function renderEditProductForm() {
     prodPageElements.set('image', prodPageImage);
     prodPageElements.set('price', prodPagePrice);
     prodPageElements.set('description', prodPageDescription);
-    prodPageElements.set('characteristics', prodPageCharacteristics);
     prodPageElements.set('references', referenceList);
 
 


### PR DESCRIPTION
Steps:
1. Click edit button
Expected: edit forms to appear for each piece of product information
Actual: The reference form did not render because the client-side code attempted to create a Characteristics form. There is no Characteristic page element anymore, which caused the script to stop prematurely.

Fix:
Remove the Characteristic element selection from script.js.