### PR TITLE
Fix: Send user to the product page from the search results.

### DIFF
--- a/final-project/static/scripts.js
+++ b/final-project/static/scripts.js
@@ -113,8 +113,11 @@ function renderProductPage(productIdentificationNumber) {
     id: productIdentificationNumber
   }
 
+  // Generate the URL for the soon to be rendered product.
+  var productUrl = Flask.url_for("render_product_page", parameters);
+
   // Render the product page with the selected product name and id.
-  window.location.replace(Flask.url_for("render_product_page", parameters));
+  window.location.replace(productUrl);
 }
 
 

--- a/final-project/templates/search.html
+++ b/final-project/templates/search.html
@@ -12,10 +12,10 @@
 
 {% block main %}
 
-    <div>
+    <div class="search-page">
         <p>Search again:</p>
         <form action="{{ url_for('search') }}" method="post">
-            <input autocomplete="off" autofocus class="form-control" name="product_name" placeholder="e.g. Macbook" type="search" required/>
+            <input autocomplete="off" autofocus class="form-control" name="product_name" placeholder="search by product name" type="search" required/>
             <button class="btn btn-default" type="submit">Submit</button>
         </form>
     </div>
@@ -28,9 +28,9 @@
 
     <div id=products_found>
         {% for product in product_info %}
-            <img src={{product["image"]}} height=250>
-            <div id=product_name>
-                {{product["product_name"]}}
+            <div id={{product["id"]}} class="clickable-products">
+                <img src={{product["image"]}} height=250>
+                <h5>{{product["product_name"]}}</h5>
             </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
Steps:
1) Search for a product
2) Get a product list
3) Click on the product image or name
Expected: Open product page
Actual: Nothing.

Fix:
Add the .clickable-products class to the search page, so that event listeners are created.